### PR TITLE
ci(config.yml): publish docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,21 @@ jobs:
       - run: npm test
       - run: npm run cov:send
       - run: npm run cov:check
+  'publish-docs':
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - run: npm run doc:publish
 
 workflows:
   version: 2
@@ -42,3 +57,11 @@ workflows:
     jobs:
       - 'node-14'
       - 'node-latest'
+      - 'publish-docs':
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - 'node-14'
+            - 'node-latest'


### PR DESCRIPTION
Setup ci to publish docs when tests pass on main only

- **What kind of change does this PR introduce?**

CI can publish docs after main branch passes the test

- **What is the current behavior?**

Doesn't publish docs

- **What is the new behavior (if this is a feature change)?**

NIL

- **Other information**:

NIL
