### PR TITLE
refactor(browserhistory.ts): forward and back returns T, visit returns void

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm test

--- a/src/lib/browserHistory.spec.ts
+++ b/src/lib/browserHistory.spec.ts
@@ -12,23 +12,31 @@ test('BrowserHistory should work correctly', (t) => {
   t.is(history.forward(1), history.root);
 
   // Visit some pages
-  const page1 = history.visit('page1');
-  const page2 = history.visit('page2');
-  const page3 = history.visit('page3');
+  const page1 = 'page1';
+  const page2 = 'page2';
+  const page3 = 'page3';
+  history.visit(page1);
+  history.visit(page2);
+  history.visit(page3);
 
   // Test the back and forward methods
-  t.is(history.back(1).value, page2.value);
-  t.is(history.back(1).value, page1.value);
-  t.is(history.back(1).value, homepage);
-  t.is(history.forward(1).value, page1.value);
-  t.is(history.forward(1).value, page2.value);
-  t.is(history.forward(1).value, page3.value);
+  t.is(history.back(1), page2);
+  t.is(history.back(1), page1);
+  t.is(history.back(1), homepage);
+  t.is(history.forward(1), page1);
+  t.is(history.forward(1), page2);
+  t.is(history.forward(1), page3);
 
   // Test visiting a new page after going back
-  const page4 = history.visit('page4');
-  t.is(history.forward(1).value, page4.value);
+  const page4 = 'page4';
+  history.visit(page4);
+  t.is(history.forward(1), page4);
 
   // Test going back and forward multiple steps
-  t.is(history.back(2).value, page2.value);
-  t.is(history.forward(2).value, page4.value);
+  t.is(history.back(2), page2);
+  t.is(history.forward(2), page4);
+
+  // Test current and root properties
+  t.is(history.current, page4);
+  t.is(history.root, homepage);
 });

--- a/src/lib/browserHistory.ts
+++ b/src/lib/browserHistory.ts
@@ -42,44 +42,72 @@ import { DoubleLinkedListNode } from './dll';
  * @template T The type of the value stored in each node
  */
 class BrowserHistory<T> {
-  root: DoubleLinkedListNode<T>;
-  current: DoubleLinkedListNode<T>;
+  private _root: DoubleLinkedListNode<T>;
+  private _current: DoubleLinkedListNode<T>;
 
+  /**
+   * @param homepage The homepage to initialize the browser history with
+   */
   constructor(homepage: T) {
-    this.root = new DoubleLinkedListNode<T>(homepage);
-    this.current = this.root;
+    this._root = new DoubleLinkedListNode<T>(homepage);
+    this._current = this._root;
   }
 
-  visit(page: T): DoubleLinkedListNode<T> {
+  /**
+   * Returns the root node's value.
+   */
+  get root(): T {
+    return this._root.value;
+  }
+
+  /**
+   * Returns the current node's value.
+   */
+  get current(): T {
+    return this._current.value;
+  }
+
+  /**
+   * @param page The page to visit
+   */
+  visit(page: T) {
     const node = new DoubleLinkedListNode<T>(page);
 
-    this.current.next = node;
-    node.prev = this.current;
-    this.current = node;
-
-    return node;
+    this._current.next = node;
+    node.prev = this._current;
+    this._current = node;
   }
 
-  back(steps: number): DoubleLinkedListNode<T> | null {
+  /**
+   * @param steps The number of steps to go back
+   * @returns The value of the node that is `steps` steps back from the current node
+   * @returns The root node's value if there is no node `steps` steps back from the current node
+   */
+  back(steps: number): T {
     let stepsLeft = steps;
 
-    while (this.current.prev && stepsLeft > 0) {
-      this.current = this.current.prev;
+    while (this._current.prev && stepsLeft > 0) {
+      this._current = this._current.prev;
       stepsLeft--;
     }
 
-    return this.current;
+    return this._current.value;
   }
 
-  forward(steps: number): DoubleLinkedListNode<T> | null {
+  /**
+   * @param steps The number of steps to go forward
+   * @returns The value of the node that is `steps` steps forward from the current node
+   * @returns The root node's value if there is no node `steps` steps forward from the current node
+   */
+  forward(steps: number): T {
     let stepsLeft = steps;
 
-    while (this.current.next && stepsLeft > 0) {
-      this.current = this.current.next;
+    while (this._current.next && stepsLeft > 0) {
+      this._current = this._current.next;
       stepsLeft--;
     }
 
-    return this.current;
+    return this._current.value;
   }
 }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- BREAKING CHANGE: visit returns void and not dll, forward and back returns T and not dll.

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
