### PR TITLE
feat(browserhistory): add getRootNode() + getCurrentNode()

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "browser",
     "double linked list",
     "linked list",
-    "linked"
+    "linked",
+    "queue",
+    "deque"
   ],
   "scripts": {
     "build": "run-p build:*",

--- a/src/lib/browserHistory.spec.ts
+++ b/src/lib/browserHistory.spec.ts
@@ -39,4 +39,8 @@ test('BrowserHistory should work correctly', (t) => {
   // Test current and root properties
   t.is(history.current, page4);
   t.is(history.root, homepage);
+
+  // Test getRootNode and getCurrentNode methods
+  t.is(history.getRootNode().value, homepage);
+  t.is(history.getCurrentNode().value, page4);
 });

--- a/src/lib/browserHistory.ts
+++ b/src/lib/browserHistory.ts
@@ -54,17 +54,31 @@ class BrowserHistory<T> {
   }
 
   /**
-   * Returns the root node's value.
+   * @returns the root node's value.
    */
   get root(): T {
     return this._root.value;
   }
 
   /**
-   * Returns the current node's value.
+   * @returns the current node's value.
    */
   get current(): T {
     return this._current.value;
+  }
+
+  /**
+   * @returns The root double linked list node
+   */
+  getRootNode(): DoubleLinkedListNode<T> {
+    return this._root;
+  }
+
+  /**
+   * @returns The current double linked list node
+   */
+  getCurrentNode(): DoubleLinkedListNode<T> {
+    return this._current;
   }
 
   /**


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

- browserHistory can now retrieve the dll node for root and current.

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
