### PR TITLE
feat(browserhistory): browser history can (de)serialize

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -24,7 +24,8 @@
     "untracked",
     "deque",
     "unshift",
-    "deserialization"
+    "deserialization",
+    "localforage"
   ],
   "flagWords": [],
   "ignorePaths": [

--- a/src/lib/browserHistory.spec.ts
+++ b/src/lib/browserHistory.spec.ts
@@ -1,46 +1,159 @@
-import test from 'ava';
+import anyTest, { TestInterface } from 'ava';
 
 import { BrowserHistory } from './browserHistory'; // Update the import path as needed
+import { DoubleLinkedListNode } from './dll';
 
-test('BrowserHistory should work correctly', (t) => {
+const test = anyTest as TestInterface<{
+  history: BrowserHistory<string>;
+  homePage: string;
+}>;
+
+const homepage = 'homepage';
+const page1 = 'page1';
+const page2 = 'page2';
+const page3 = 'page3';
+const page4 = 'page4';
+
+test.before((t) => {
   // Initialize a BrowserHistory instance
-  const homepage = 'homepage';
-  const history = new BrowserHistory<string>(homepage);
+  t.context.history = new BrowserHistory<string>(homepage);
+});
 
+test('BrowserHistory initial state', (t) => {
   // Test the initial state
-  t.is(history.back(1), history.root);
-  t.is(history.forward(1), history.root);
+  t.is(t.context.history.back(1), t.context.history.root);
+  t.is(t.context.history.forward(1), t.context.history.root);
+});
 
+test('Back and forward methods should work correctly', (t) => {
   // Visit some pages
-  const page1 = 'page1';
-  const page2 = 'page2';
-  const page3 = 'page3';
+  t.context.history.visit(page1);
+  t.context.history.visit(page2);
+  t.context.history.visit(page3);
+
+  // Test the back and forward methods
+  t.is(t.context.history.back(1), page2);
+  t.is(t.context.history.back(1), page1);
+  t.is(t.context.history.back(1), homepage);
+  t.is(t.context.history.forward(1), page1);
+  t.is(t.context.history.forward(1), page2);
+  t.is(t.context.history.forward(1), page3);
+});
+
+test('current and root properties after visiting and going back', (t) => {
+  // Test visiting a new page after going back
+  t.context.history.visit(page4);
+  t.is(t.context.history.forward(1), page4);
+
+  // Test going back and forward multiple steps
+  t.is(t.context.history.back(2), page2);
+  t.is(t.context.history.forward(2), page4);
+
+  // Test current and root properties
+  t.is(t.context.history.current, page4);
+  t.is(t.context.history.root, homepage);
+});
+
+test('getRootNode and getCurrentNode methods', (t) => {
+  t.is(t.context.history.getRootNode().value, homepage);
+  t.is(t.context.history.getCurrentNode().value, page4);
+});
+
+test('getSerializedRoot and getSerializedCurrent methods', (t) => {
+  // Test getSerializedRoot and getSerializedCurrent methods
+  t.deepEqual(t.context.history.getSerializedRoot(), [
+    {
+      value: homepage,
+      next: page1,
+      prev: null,
+    },
+    {
+      value: page1,
+      prev: homepage,
+      next: page2,
+    },
+    {
+      value: page2,
+      prev: page1,
+      next: page3,
+    },
+    {
+      value: page3,
+      prev: page2,
+      next: page4,
+    },
+    {
+      value: page4,
+      prev: page3,
+      next: null,
+    },
+  ]);
+
+  const page5 = 'page5';
+  t.context.history.visit(page5);
+  t.context.history.back(1);
+
+  // First node should be page4
+  t.deepEqual(t.context.history.getSerializedCurrent(), [
+    {
+      value: page4,
+      next: page5,
+      prev: page3,
+    },
+    {
+      value: page5,
+      next: null,
+      prev: page4,
+    },
+    {
+      value: page3,
+      next: page4,
+      prev: page2,
+    },
+    {
+      value: page2,
+      next: page3,
+      prev: page1,
+    },
+    {
+      value: page1,
+      next: page2,
+      prev: homepage,
+    },
+    {
+      value: homepage,
+      next: page1,
+      prev: null,
+    },
+  ]);
+});
+
+test('setRootNode and setCurrentNode methods', (t) => {
+  // Test setRootNode and setCurrentNode methods
+  const page5 = new DoubleLinkedListNode('page5');
+  const page6 = new DoubleLinkedListNode('page6');
+
+  page5.next = page6;
+  page6.prev = page5;
+
+  t.context.history.setNode(page6);
+
+  t.is(t.context.history.getRootNode(), page5);
+  t.is(t.context.history.getCurrentNode(), page6);
+});
+
+test('no homepage', (t) => {
+  // Test no homepage
+  const history = new BrowserHistory<string>();
+
   history.visit(page1);
   history.visit(page2);
   history.visit(page3);
 
-  // Test the back and forward methods
   t.is(history.back(1), page2);
   t.is(history.back(1), page1);
-  t.is(history.back(1), homepage);
+  t.is(history.back(1), null);
   t.is(history.forward(1), page1);
   t.is(history.forward(1), page2);
   t.is(history.forward(1), page3);
-
-  // Test visiting a new page after going back
-  const page4 = 'page4';
-  history.visit(page4);
-  t.is(history.forward(1), page4);
-
-  // Test going back and forward multiple steps
-  t.is(history.back(2), page2);
-  t.is(history.forward(2), page4);
-
-  // Test current and root properties
-  t.is(history.current, page4);
-  t.is(history.root, homepage);
-
-  // Test getRootNode and getCurrentNode methods
-  t.is(history.getRootNode().value, homepage);
-  t.is(history.getCurrentNode().value, page4);
 });

--- a/src/lib/browserHistory.ts
+++ b/src/lib/browserHistory.ts
@@ -1,4 +1,5 @@
 import { DoubleLinkedListNode } from './dll';
+import { serializeDoubleLinkedList } from './dllSerialization';
 
 /**
  * A BrowserHistory class that implements a doubly linked list.
@@ -48,7 +49,7 @@ class BrowserHistory<T> {
   /**
    * @param homepage The homepage to initialize the browser history with
    */
-  constructor(homepage: T) {
+  constructor(homepage: T = null) {
     this._root = new DoubleLinkedListNode<T>(homepage);
     this._current = this._root;
   }
@@ -122,6 +123,39 @@ class BrowserHistory<T> {
     }
 
     return this._current.value;
+  }
+
+  /**
+   * setNode sets the current node as the @param node and sets the head of @param node as the root node.
+   *
+   * @param node a doubly linked list node
+   */
+  setNode(node: DoubleLinkedListNode<T>): void {
+    this._current = node;
+
+    while (node.prev) {
+      node = node.prev;
+    }
+
+    this._root = node;
+  }
+
+  /**
+   * serializes the root node of the browser history, so that it can be stored in a database or send over the network.
+   *
+   * @returns an array of objects representing the doubly linked list, where the first index 0 is the root node
+   */
+  getSerializedRoot(): { value: T; next: T | null; prev: T | null }[] {
+    return serializeDoubleLinkedList(this._root);
+  }
+
+  /**
+   * serializes the current node of the browser history, so that it can be stored in a database or send over the network.
+   *
+   * @returns an array of objects representing the doubly linked list, where the first index 0 is the current node
+   */
+  getSerializedCurrent(): { value: T; next: T | null; prev: T | null }[] {
+    return serializeDoubleLinkedList(this._current);
   }
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** 

- browser history can now serialize and deserialize a double linked list node for saving to a database or send over the network

**What is the current behavior?** (You can also link to an open issue here)

- browser history does not have ability to override or set a new root and current node

**What is the new behavior (if this is a feature change)?**

- browser history can now serialize and deserialize the root and current node

**Other information**:

- NIL