### PR TITLE
refactor(browserhistory): browser history does not expose DLL

### DIFF
--- a/src/lib/browserHistory.spec.ts
+++ b/src/lib/browserHistory.spec.ts
@@ -1,7 +1,6 @@
 import anyTest, { TestInterface } from 'ava';
 
 import { BrowserHistory } from './browserHistory'; // Update the import path as needed
-import { DoubleLinkedListNode } from './dll';
 
 const test = anyTest as TestInterface<{
   history: BrowserHistory<string>;
@@ -21,8 +20,8 @@ test.before((t) => {
 
 test('BrowserHistory initial state', (t) => {
   // Test the initial state
-  t.is(t.context.history.back(1), t.context.history.root);
-  t.is(t.context.history.forward(1), t.context.history.root);
+  t.is(t.context.history.back(1).pathname, homepage);
+  t.is(t.context.history.forward(1).pathname, homepage);
 });
 
 test('Back and forward methods should work correctly', (t) => {
@@ -32,128 +31,101 @@ test('Back and forward methods should work correctly', (t) => {
   t.context.history.visit(page3);
 
   // Test the back and forward methods
-  t.is(t.context.history.back(1), page2);
-  t.is(t.context.history.back(1), page1);
-  t.is(t.context.history.back(1), homepage);
-  t.is(t.context.history.forward(1), page1);
-  t.is(t.context.history.forward(1), page2);
-  t.is(t.context.history.forward(1), page3);
+  t.is(t.context.history.back(1).pathname, page2);
+  t.is(t.context.history.back(1).pathname, page1);
+  t.is(t.context.history.back(1).pathname, homepage);
+  t.is(t.context.history.forward(1).pathname, page1);
+  t.is(t.context.history.forward(1).pathname, page2);
+  t.is(t.context.history.forward(1).pathname, page3);
 });
 
 test('current and root properties after visiting and going back', (t) => {
   // Test visiting a new page after going back
   t.context.history.visit(page4);
-  t.is(t.context.history.forward(1), page4);
+  t.is(t.context.history.forward(1).pathname, page4);
 
   // Test going back and forward multiple steps
-  t.is(t.context.history.back(2), page2);
-  t.is(t.context.history.forward(2), page4);
+  t.is(t.context.history.back(2).pathname, page2);
+  t.is(t.context.history.forward(2).pathname, page4);
 
   // Test current and root properties
-  t.is(t.context.history.current, page4);
-  t.is(t.context.history.root, homepage);
+  t.is(t.context.history.getCurrentPage().pathname, page4);
+  t.is(t.context.history.getHomePage().pathname, homepage);
 });
 
-test('getRootNode and getCurrentNode methods', (t) => {
-  t.is(t.context.history.getRootNode().value, homepage);
-  t.is(t.context.history.getCurrentNode().value, page4);
+test('Back and forward methods should work correctly after visiting a new page', (t) => {
+  // Test visiting a new page
+  t.context.history.visit(page1);
+  t.is(t.context.history.back(1).pathname, page4);
+  t.is(t.context.history.forward(1).pathname, page1);
 });
 
-test('getSerializedRoot and getSerializedCurrent methods', (t) => {
-  // Test getSerializedRoot and getSerializedCurrent methods
-  t.deepEqual(t.context.history.getSerializedRoot(), [
-    {
-      value: homepage,
-      next: page1,
-      prev: null,
-    },
-    {
-      value: page1,
-      prev: homepage,
-      next: page2,
-    },
-    {
-      value: page2,
-      prev: page1,
-      next: page3,
-    },
-    {
-      value: page3,
-      prev: page2,
-      next: page4,
-    },
-    {
-      value: page4,
-      prev: page3,
-      next: null,
-    },
-  ]);
-
-  const page5 = 'page5';
-  t.context.history.visit(page5);
-  t.context.history.back(1);
-
-  // First node should be page4
-  t.deepEqual(t.context.history.getSerializedCurrent(), [
-    {
-      value: page4,
-      next: page5,
-      prev: page3,
-    },
-    {
-      value: page5,
-      next: null,
-      prev: page4,
-    },
-    {
-      value: page3,
-      next: page4,
-      prev: page2,
-    },
-    {
-      value: page2,
-      next: page3,
-      prev: page1,
-    },
-    {
-      value: page1,
-      next: page2,
-      prev: homepage,
-    },
-    {
-      value: homepage,
-      next: page1,
-      prev: null,
-    },
-  ]);
-});
-
-test('setRootNode and setCurrentNode methods', (t) => {
-  // Test setRootNode and setCurrentNode methods
-  const page5 = new DoubleLinkedListNode('page5');
-  const page6 = new DoubleLinkedListNode('page6');
-
-  page5.next = page6;
-  page6.prev = page5;
-
-  t.context.history.setNode(page6);
-
-  t.is(t.context.history.getRootNode(), page5);
-  t.is(t.context.history.getCurrentNode(), page6);
-});
-
-test('no homepage', (t) => {
-  // Test no homepage
-  const history = new BrowserHistory<string>();
-
-  history.visit(page1);
-  history.visit(page2);
-  history.visit(page3);
-
-  t.is(history.back(1), page2);
-  t.is(history.back(1), page1);
-  t.is(history.back(1), null);
-  t.is(history.forward(1), page1);
-  t.is(history.forward(1), page2);
-  t.is(history.forward(1), page3);
+test('serialize method should work correctly', (t) => {
+  // Test the serialize method
+  t.deepEqual(t.context.history.serializeHistory(), {
+    homePage: [
+      {
+        value: { pathname: 'homepage', state: undefined },
+        prev: null,
+        next: { pathname: 'page1', state: undefined },
+      },
+      {
+        value: { pathname: 'page1', state: undefined },
+        prev: { pathname: 'homepage', state: undefined },
+        next: { pathname: 'page2', state: undefined },
+      },
+      {
+        value: { pathname: 'page2', state: undefined },
+        prev: { pathname: 'page1', state: undefined },
+        next: { pathname: 'page3', state: undefined },
+      },
+      {
+        value: { pathname: 'page3', state: undefined },
+        prev: { pathname: 'page2', state: undefined },
+        next: { pathname: 'page4', state: undefined },
+      },
+      {
+        value: { pathname: 'page4', state: undefined },
+        prev: { pathname: 'page3', state: undefined },
+        next: { pathname: 'page1', state: undefined },
+      },
+      {
+        value: { pathname: 'page1', state: undefined },
+        prev: { pathname: 'page4', state: undefined },
+        next: null,
+      },
+    ],
+    currentPage: [
+      {
+        value: { pathname: 'page1', state: undefined },
+        prev: { pathname: 'page4', state: undefined },
+        next: null,
+      },
+      {
+        value: { pathname: 'page4', state: undefined },
+        prev: { pathname: 'page3', state: undefined },
+        next: { pathname: 'page1', state: undefined },
+      },
+      {
+        value: { pathname: 'page3', state: undefined },
+        prev: { pathname: 'page2', state: undefined },
+        next: { pathname: 'page4', state: undefined },
+      },
+      {
+        value: { pathname: 'page2', state: undefined },
+        prev: { pathname: 'page1', state: undefined },
+        next: { pathname: 'page3', state: undefined },
+      },
+      {
+        value: { pathname: 'page1', state: undefined },
+        prev: { pathname: 'homepage', state: undefined },
+        next: { pathname: 'page2', state: undefined },
+      },
+      {
+        value: { pathname: 'homepage', state: undefined },
+        prev: null,
+        next: { pathname: 'page1', state: undefined },
+      },
+    ],
+  });
 });

--- a/src/lib/browserHistory.ts
+++ b/src/lib/browserHistory.ts
@@ -1,3 +1,5 @@
+import { ILocationState, ISerializedHistory } from '../types/browserHistory';
+
 import { DoubleLinkedListNode } from './dll';
 import { serializeDoubleLinkedList } from './dllSerialization';
 
@@ -43,50 +45,44 @@ import { serializeDoubleLinkedList } from './dllSerialization';
  * @template T The type of the value stored in each node
  */
 class BrowserHistory<T> {
-  private _root: DoubleLinkedListNode<T>;
-  private _current: DoubleLinkedListNode<T>;
+  private _root: DoubleLinkedListNode<ILocationState<T>>;
+  private _current: DoubleLinkedListNode<ILocationState<T>>;
 
   /**
    * @param homepage The homepage to initialize the browser history with
    */
-  constructor(homepage: T = null) {
-    this._root = new DoubleLinkedListNode<T>(homepage);
+  constructor(homepageUrl: string, state?: T) {
+    this._root = new DoubleLinkedListNode<ILocationState<T>>({
+      pathname: homepageUrl,
+      state: state,
+    });
     this._current = this._root;
   }
 
   /**
-   * @returns the root node's value.
+   *
+   * @returns the homepage's pathname and state
    */
-  get root(): T {
+  getHomePage(): ILocationState<T> {
     return this._root.value;
   }
 
   /**
-   * @returns the current node's value.
+   *
+   * @returns the current page's pathname and state
    */
-  get current(): T {
+  getCurrentPage(): ILocationState<T> {
     return this._current.value;
   }
 
   /**
-   * @returns The root double linked list node
+   * @param page The page or pathname to visit
    */
-  getRootNode(): DoubleLinkedListNode<T> {
-    return this._root;
-  }
-
-  /**
-   * @returns The current double linked list node
-   */
-  getCurrentNode(): DoubleLinkedListNode<T> {
-    return this._current;
-  }
-
-  /**
-   * @param page The page to visit
-   */
-  visit(page: T) {
-    const node = new DoubleLinkedListNode<T>(page);
+  visit(page: string, state?: T) {
+    const node = new DoubleLinkedListNode<ILocationState<T>>({
+      pathname: page,
+      state,
+    });
 
     this._current.next = node;
     node.prev = this._current;
@@ -95,10 +91,10 @@ class BrowserHistory<T> {
 
   /**
    * @param steps The number of steps to go back
-   * @returns The value of the node that is `steps` steps back from the current node
-   * @returns The root node's value if there is no node `steps` steps back from the current node
+   * @returns The pathname and state that is the number of steps back from the current page
+   * @returns The homepage pathname and state if there is no more pages `steps` steps back from the current page
    */
-  back(steps: number): T {
+  back(steps: number): ILocationState<T> {
     let stepsLeft = steps;
 
     while (this._current.prev && stepsLeft > 0) {
@@ -111,10 +107,10 @@ class BrowserHistory<T> {
 
   /**
    * @param steps The number of steps to go forward
-   * @returns The value of the node that is `steps` steps forward from the current node
-   * @returns The root node's value if there is no node `steps` steps forward from the current node
+   * @returns The pathname and state that is `steps` steps forward from the current page
+   * @returns The homepage pathname and state if there is no more pages `steps` steps forward from the current page
    */
-  forward(steps: number): T {
+  forward(steps: number): ILocationState<T> {
     let stepsLeft = steps;
 
     while (this._current.next && stepsLeft > 0) {
@@ -126,36 +122,14 @@ class BrowserHistory<T> {
   }
 
   /**
-   * setNode sets the current node as the @param node and sets the head of @param node as the root node.
    *
-   * @param node a doubly linked list node
+   * @returns A serialized version of the browser history
    */
-  setNode(node: DoubleLinkedListNode<T>): void {
-    this._current = node;
-
-    while (node.prev) {
-      node = node.prev;
-    }
-
-    this._root = node;
-  }
-
-  /**
-   * serializes the root node of the browser history, so that it can be stored in a database or send over the network.
-   *
-   * @returns an array of objects representing the doubly linked list, where the first index 0 is the root node
-   */
-  getSerializedRoot(): { value: T; next: T | null; prev: T | null }[] {
-    return serializeDoubleLinkedList(this._root);
-  }
-
-  /**
-   * serializes the current node of the browser history, so that it can be stored in a database or send over the network.
-   *
-   * @returns an array of objects representing the doubly linked list, where the first index 0 is the current node
-   */
-  getSerializedCurrent(): { value: T; next: T | null; prev: T | null }[] {
-    return serializeDoubleLinkedList(this._current);
+  serializeHistory(): ISerializedHistory<T> {
+    return {
+      homePage: serializeDoubleLinkedList(this._root),
+      currentPage: serializeDoubleLinkedList(this._current),
+    };
   }
 }
 

--- a/src/types/browserHistory.ts
+++ b/src/types/browserHistory.ts
@@ -1,0 +1,11 @@
+import { IDllSerializedList } from './dllSerialization';
+
+export interface ILocationState<T> {
+  pathname: string;
+  state: T;
+}
+
+export interface ISerializedHistory<T> {
+  homePage: IDllSerializedList<ILocationState<T>>;
+  currentPage: IDllSerializedList<ILocationState<T>>;
+}


### PR DESCRIPTION
The browser history api was exposing a 'node' as opposed to url and associated state which has too much of an abstraction for a browser class

BREAKING CHANGE: back and forward returns the pathname and state rather than a 'node'

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
