### PR TITLE
refactor(browserhistory): browser history does not expose DLL as an api

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,57 +33,12 @@ const page1 = history.visit('page1');
 const page2 = history.visit('page2');
 const page3 = history.visit('page3');
 
-history.back(1); // => page2
-history.back(1); // => page1
-history.back(1); // => homepage
-history.forward(1); // => page1
-history.forward(1); // => page2
-history.forward(1); // => page3
-```
-
-You can use this to manage a user's history between separate applications by storing the serialized data:
-
-```js
-(async () => {
-  import * as localforage from 'localforage';
-  import { BrowserHistory, deserializeDoubleLinkedList, IDllSerializedList } from 'spectrum-kit';
-
-  interface IPageState {
-    url: string;
-    pageState: { rowOffset: number };
-  }
-  const userId = "123";
-
-  const setHistory =
-    (browserHistory: BrowserHistory<IPageState>) =>
-    async (userId: string, state: IPageState) => {
-      browserHistory.visit(state);
-
-      return await localforage.setItem<IDllSerializedList<IPageState>>(
-        userId,
-        browserHistory.getSerializedCurrent()
-      );
-    };
-
-  const browserHistory = new BrowserHistory<IPageState>({
-    url: "/",
-    pageState: { rowOffset: 0 },
-  });
-
-  const history = await setHistory(browserHistory)(userId, {
-    url: "/foo",
-    pageState: { rowOffset: 10 },
-  });
-
-  console.log(history);
-  console.log(
-    await localforage.getItem<IDllSerializedList<IPageState>>(userId)
-  );
-  // [
-  //    { value: { url: '/', pageState: { rowOffset: 0 } }, prev: null, next: '/foo'},
-  //    { value: { url: '/foo', pageState: { rowOffset: 10 } }, prev: '/', next: null }
-  // ]
-})();
+ history.back(1); // => { pathname: page2, state: undefined }
+ history.back(1); // => { pathname: page1, state: undefined }
+ history.back(1); // => { pathname: homepage, state: undefined }
+ history.forward(1); // => { pathname: page1, state: undefined }
+ history.forward(1); // => { pathname: page2, state: undefined }
+ history.forward(1); // => { pathname: page3, state: undefined }
 ```
 
 ### Serialization
@@ -95,7 +50,7 @@ To store your BrowserHistory data in a database, IndexedDB, or localStorage, you
 import { serializeDoubleLinkedList } from 'spectrum-kit';
 
 // Assuming you have a BrowserHistory instance called 'history'
-const serializedData = serializeDoubleLinkedList(history.getRootNode());
+const serializedData = history.serializeHistory();
 
 // Now, you can store the 'serializedData' array in your preferred storage solution
 // (e.g., IndexedDB, localStorage, or a database).
@@ -106,17 +61,17 @@ const serializedData = serializeDoubleLinkedList(history.getRootNode());
 To retrieve and reconstruct your BrowserHistory data from storage, you can use the deserializeDoubleLinkedList function. This function takes the serialized data as input and reconstructs the doubly linked list, allowing you to continue using it.
 
 ```js
-// Import the deserializeDoubleLinkedList function
-import { deSerializeDoubleLinkedList } from 'spectrum-kit';
+import { BrowserHistory } from 'spectrum-kit';
 
-// Retrieve the serialized data from your storage solution (e.g., IndexedDB or localStorage)
+
+// Retrieve the serialized data from your storage solution (e.g., IndexedDB or localStorage), must be serialized using
+// serializeDoubleLinkedList in this repo
 const storedData = /* Retrieve your data here */;
 
-// Deserialize the data to reconstruct the BrowserHistory
-const deserializedList = deserializeDoubleLinkedList(storedData);
+// Deserialize the data 
+const history = new BrowserHistory('');
 
-// You can now use 'deserializedList' as a BrowserHistory instance with your history data.
-
+history.deserializeHistory(storedData);
 ```
 
 ### DoubleLinkedListNode

--- a/src/lib/browserHistory.spec.ts
+++ b/src/lib/browserHistory.spec.ts
@@ -60,72 +60,94 @@ test('Back and forward methods should work correctly after visiting a new page',
   t.is(t.context.history.forward(1).pathname, page1);
 });
 
+const historyTestDouble = {
+  homePage: [
+    {
+      key: 'homepage',
+      value: undefined,
+      prev: null,
+      next: { key: 'page1', value: undefined },
+    },
+    {
+      key: 'page1',
+      value: undefined,
+      prev: { key: 'homepage', value: undefined },
+      next: { key: 'page2', value: undefined },
+    },
+    {
+      key: 'page2',
+      value: undefined,
+      prev: { key: 'page1', value: undefined },
+      next: { key: 'page3', value: undefined },
+    },
+    {
+      key: 'page3',
+      value: undefined,
+      prev: { key: 'page2', value: undefined },
+      next: { key: 'page4', value: undefined },
+    },
+    {
+      key: 'page4',
+      value: undefined,
+      prev: { key: 'page3', value: undefined },
+      next: { key: 'page1', value: undefined },
+    },
+    {
+      key: 'page1',
+      value: undefined,
+      prev: { key: 'page4', value: undefined },
+      next: null,
+    },
+  ],
+  currentPage: [
+    {
+      key: 'page1',
+      value: undefined,
+      prev: { key: 'page4', value: undefined },
+      next: null,
+    },
+    {
+      key: 'page4',
+      value: undefined,
+      prev: { key: 'page3', value: undefined },
+      next: { key: 'page1', value: undefined },
+    },
+    {
+      key: 'page3',
+      value: undefined,
+      prev: { key: 'page2', value: undefined },
+      next: { key: 'page4', value: undefined },
+    },
+    {
+      key: 'page2',
+      value: undefined,
+      prev: { key: 'page1', value: undefined },
+      next: { key: 'page3', value: undefined },
+    },
+    {
+      key: 'page1',
+      value: undefined,
+      prev: { key: 'homepage', value: undefined },
+      next: { key: 'page2', value: undefined },
+    },
+    {
+      key: 'homepage',
+      value: undefined,
+      prev: null,
+      next: { key: 'page1', value: undefined },
+    },
+  ],
+};
+
 test('serialize method should work correctly', (t) => {
   // Test the serialize method
-  t.deepEqual(t.context.history.serializeHistory(), {
-    homePage: [
-      {
-        value: { pathname: 'homepage', state: undefined },
-        prev: null,
-        next: { pathname: 'page1', state: undefined },
-      },
-      {
-        value: { pathname: 'page1', state: undefined },
-        prev: { pathname: 'homepage', state: undefined },
-        next: { pathname: 'page2', state: undefined },
-      },
-      {
-        value: { pathname: 'page2', state: undefined },
-        prev: { pathname: 'page1', state: undefined },
-        next: { pathname: 'page3', state: undefined },
-      },
-      {
-        value: { pathname: 'page3', state: undefined },
-        prev: { pathname: 'page2', state: undefined },
-        next: { pathname: 'page4', state: undefined },
-      },
-      {
-        value: { pathname: 'page4', state: undefined },
-        prev: { pathname: 'page3', state: undefined },
-        next: { pathname: 'page1', state: undefined },
-      },
-      {
-        value: { pathname: 'page1', state: undefined },
-        prev: { pathname: 'page4', state: undefined },
-        next: null,
-      },
-    ],
-    currentPage: [
-      {
-        value: { pathname: 'page1', state: undefined },
-        prev: { pathname: 'page4', state: undefined },
-        next: null,
-      },
-      {
-        value: { pathname: 'page4', state: undefined },
-        prev: { pathname: 'page3', state: undefined },
-        next: { pathname: 'page1', state: undefined },
-      },
-      {
-        value: { pathname: 'page3', state: undefined },
-        prev: { pathname: 'page2', state: undefined },
-        next: { pathname: 'page4', state: undefined },
-      },
-      {
-        value: { pathname: 'page2', state: undefined },
-        prev: { pathname: 'page1', state: undefined },
-        next: { pathname: 'page3', state: undefined },
-      },
-      {
-        value: { pathname: 'page1', state: undefined },
-        prev: { pathname: 'homepage', state: undefined },
-        next: { pathname: 'page2', state: undefined },
-      },
-      {
-        value: { pathname: 'homepage', state: undefined },
-        prev: null,
-        next: { pathname: 'page1', state: undefined },
-      },
-    ],
-  });
+  t.deepEqual(t.context.history.serializeHistory(), historyTestDouble);
+});
+
+test('deserialize method should work correctly', (t) => {
+  t.context.history.deserializeHistory(historyTestDouble);
+  t.is(t.context.history.back(1).pathname, page4);
+  t.is(t.context.history.forward(1).pathname, page1);
+  t.is(t.context.history.getHomePage().pathname, homepage);
+  t.is(t.context.history.getCurrentPage().pathname, page1);
 });

--- a/src/lib/deque.ts
+++ b/src/lib/deque.ts
@@ -1,5 +1,3 @@
-import { DoubleLinkedListNode } from './dll';
-
 /**
  * A double ended queue using a double linked list, where
  * .popLeft() and .appendLeft() will be a time complexity
@@ -210,6 +208,18 @@ class Deque<T> {
     this._head = null;
     this._tail = null;
     this._size = 0;
+  }
+}
+
+class DoubleLinkedListNode<T> {
+  value: T;
+  next: DoubleLinkedListNode<T> | null;
+  prev: DoubleLinkedListNode<T> | null;
+
+  constructor(value: T) {
+    this.value = value;
+    this.next = null;
+    this.prev = null;
   }
 }
 

--- a/src/lib/dll.spec.ts
+++ b/src/lib/dll.spec.ts
@@ -3,15 +3,16 @@ import test from 'ava';
 import { DoubleLinkedListNode } from './dll';
 
 test('should create a node with the given value', (t) => {
-  const node = new DoubleLinkedListNode(42);
+  const node = new DoubleLinkedListNode('1', 42);
+  t.is(node.key, '1');
   t.is(node.value, 42);
   t.is(node.next, null);
   t.is(node.prev, null);
 });
 
 test('should link nodes correctly', (t) => {
-  const node1 = new DoubleLinkedListNode(1);
-  const node2 = new DoubleLinkedListNode(2);
+  const node1 = new DoubleLinkedListNode('1', 1);
+  const node2 = new DoubleLinkedListNode('two', 2);
 
   node1.next = node2;
   node2.prev = node1;

--- a/src/lib/dll.ts
+++ b/src/lib/dll.ts
@@ -24,11 +24,13 @@
  * @template T The type of the value stored in the node
  */
 class DoubleLinkedListNode<T> {
+  key: string;
   value: T;
   next: DoubleLinkedListNode<T> | null;
   prev: DoubleLinkedListNode<T> | null;
 
-  constructor(value: T) {
+  constructor(key: string, value: T) {
+    this.key = key;
     this.value = value;
     this.next = null;
     this.prev = null;

--- a/src/lib/dllSerialization.spec.ts
+++ b/src/lib/dllSerialization.spec.ts
@@ -12,9 +12,9 @@ test('Deserialize an empty list', (t) => {
 
 test('Serialize and deserialize a doubly linked list', (t) => {
   // Create a sample doubly linked list
-  const node1 = new DoubleLinkedListNode(1);
-  const node2 = new DoubleLinkedListNode(2);
-  const node3 = new DoubleLinkedListNode(3);
+  const node1 = new DoubleLinkedListNode('1', 1);
+  const node2 = new DoubleLinkedListNode('2', 2);
+  const node3 = new DoubleLinkedListNode('3', 3);
 
   node1.next = node2;
   node2.prev = node1;
@@ -29,20 +29,25 @@ test('Serialize and deserialize a doubly linked list', (t) => {
 
   // Check that the deserialized list is correct
   t.is(deserializedList.value, 1);
+  t.is(deserializedList.key, '1');
   t.is(deserializedList.next.value, 2);
+  t.is(deserializedList.next.key, '2');
   t.is(deserializedList.next.prev.value, 1);
+  t.is(deserializedList.next.prev.key, '1');
   t.is(deserializedList.next.next.value, 3);
+  t.is(deserializedList.next.next.key, '3');
   t.is(deserializedList.next.next.prev.value, 2);
+  t.is(deserializedList.next.next.prev.key, '2');
   t.is(deserializedList.next.next.next, null);
 });
 
 test('Serialize and deserialize a doubly linked list with a prev node', (t) => {
-  const node11 = new DoubleLinkedListNode(11);
-  const node10 = new DoubleLinkedListNode(10);
-  const node0 = new DoubleLinkedListNode(0);
-  const node1 = new DoubleLinkedListNode(1);
-  const node2 = new DoubleLinkedListNode(2);
-  const node3 = new DoubleLinkedListNode(3);
+  const node11 = new DoubleLinkedListNode('11', 11);
+  const node10 = new DoubleLinkedListNode('10', 10);
+  const node0 = new DoubleLinkedListNode('0', 0);
+  const node1 = new DoubleLinkedListNode('1', 1);
+  const node2 = new DoubleLinkedListNode('2', 2);
+  const node3 = new DoubleLinkedListNode('3', 3);
 
   node11.next = node10;
   node10.prev = node11;
@@ -91,9 +96,14 @@ test('Serialize and deserialize an empty doubly linked list', (t) => {
 test('Deserialize a doubly linked list with no prev pointers', (t) => {
   // Create a serialized representation of a doubly linked list with no prev pointers
   const serializedData = [
-    { value: 1, next: 2, prev: null },
-    { value: 2, prev: 1, next: 3 },
-    { value: 3, prev: 2, next: null },
+    { key: '1', value: 1, next: { key: '2', value: 2 }, prev: null },
+    {
+      key: '2',
+      value: 2,
+      prev: { key: '1', value: 1 },
+      next: { key: '3', value: 3 },
+    },
+    { key: '3', value: 3, prev: { key: '2', value: 2 }, next: null },
   ];
 
   // Deserialize the data
@@ -113,33 +123,39 @@ test('Deserialize a doubly linked list with no prev pointers', (t) => {
 test('Deserialize a doubly linked list with next pointers', (t) => {
   const serializedData = [
     {
+      key: 'page4',
       value: 'page4',
-      next: 'page5',
-      prev: 'page3',
+      next: { key: 'page5', value: 'page5' },
+      prev: { key: 'page3', value: 'page3' },
     },
     {
+      key: 'page3',
       value: 'page3',
-      next: 'page4',
-      prev: 'page2',
+      next: { key: 'page4', value: 'page4' },
+      prev: { key: 'page2', value: 'page2' },
     },
     {
+      key: 'page2',
       value: 'page2',
-      next: 'page3',
-      prev: 'page1',
+      next: { key: 'page3', value: 'page3' },
+      prev: { key: 'page1', value: 'page1' },
     },
     {
+      key: 'page1',
       value: 'page1',
-      next: 'page2',
-      prev: 'homepage',
+      next: { key: 'page2', value: 'page2' },
+      prev: { key: 'homepage', value: 'homepage' },
     },
     {
+      key: 'homepage',
       value: 'homepage',
-      next: 'page1',
+      next: { key: 'page1', value: 'page1' },
       prev: null,
     },
     {
+      key: 'page5',
       value: 'page5',
-      prev: 'page4',
+      prev: { key: 'page4', value: 'page4' },
       next: null,
     },
   ];
@@ -151,24 +167,38 @@ test('Deserialize a doubly linked list with next pointers', (t) => {
 
   while (dllNextTest.next) {
     if (i === 0) {
+      t.is(dllNextTest.key, 'page4');
       t.is(dllNextTest.value, 'page4');
+      t.is(dllNextTest.next.key, 'page5');
       t.is(dllNextTest.next.value, 'page5');
+      t.is(dllNextTest.prev.key, 'page3');
       t.is(dllNextTest.prev.value, 'page3');
     } else if (i === 1) {
+      t.is(dllNextTest.key, 'page3');
       t.is(dllNextTest.value, 'page3');
+      t.is(dllNextTest.next.key, 'page4');
       t.is(dllNextTest.next.value, 'page4');
+      t.is(dllNextTest.prev.key, 'page2');
       t.is(dllNextTest.prev.value, 'page2');
     } else if (i === 2) {
+      t.is(dllNextTest.key, 'page2');
       t.is(dllNextTest.value, 'page2');
+      t.is(dllNextTest.next.key, 'page3');
       t.is(dllNextTest.next.value, 'page3');
+      t.is(dllNextTest.prev.key, 'page1');
       t.is(dllNextTest.prev.value, 'page1');
     } else if (i === 3) {
+      t.is(dllNextTest.key, 'page1');
       t.is(dllNextTest.value, 'page1');
+      t.is(dllNextTest.next.key, 'page2');
       t.is(dllNextTest.next.value, 'page2');
+      t.is(dllNextTest.prev.key, 'homepage');
       t.is(dllNextTest.prev.value, 'homepage');
     } else {
       t.is(dllNextTest.value, 'homepage');
+      t.is(dllNextTest.key, 'homepage');
       t.is(dllNextTest.next.value, 'page1');
+      t.is(dllNextTest.next.key, 'page1');
       t.is(dllNextTest.prev, null);
     }
     dllNextTest = dllNextTest.next;
@@ -181,24 +211,38 @@ test('Deserialize a doubly linked list with next pointers', (t) => {
 
   while (dllPrevTest.prev) {
     if (j === 4) {
+      t.is(dllPrevTest.key, 'homepage');
       t.is(dllPrevTest.value, 'homepage');
       t.is(dllPrevTest.prev, null);
       t.is(dllPrevTest.next.value, 'page1');
+      t.is(dllPrevTest.next.key, 'page1');
     } else if (j === 3) {
+      t.is(dllPrevTest.key, 'page1');
       t.is(dllPrevTest.value, 'page1');
+      t.is(dllPrevTest.prev.key, 'homepage');
       t.is(dllPrevTest.prev.value, 'homepage');
+      t.is(dllPrevTest.next.key, 'page2');
       t.is(dllPrevTest.next.value, 'page2');
     } else if (j === 2) {
+      t.is(dllPrevTest.key, 'page2');
       t.is(dllPrevTest.value, 'page2');
+      t.is(dllPrevTest.prev.key, 'page1');
       t.is(dllPrevTest.prev.value, 'page1');
+      t.is(dllPrevTest.next.key, 'page3');
       t.is(dllPrevTest.next.value, 'page3');
     } else if (j === 1) {
+      t.is(dllPrevTest.key, 'page3');
       t.is(dllPrevTest.value, 'page3');
+      t.is(dllPrevTest.prev.key, 'page2');
       t.is(dllPrevTest.prev.value, 'page2');
+      t.is(dllPrevTest.next.key, 'page4');
       t.is(dllPrevTest.next.value, 'page4');
     } else if (j === 0) {
+      t.is(dllPrevTest.key, 'page4');
       t.is(dllPrevTest.value, 'page4');
+      t.is(dllPrevTest.prev.key, 'page3');
       t.is(dllPrevTest.prev.value, 'page3');
+      t.is(dllPrevTest.next.key, 'page5');
       t.is(dllPrevTest.next.value, 'page5');
     }
     dllPrevTest = dllPrevTest.prev;

--- a/src/lib/dllSerialization.ts
+++ b/src/lib/dllSerialization.ts
@@ -21,17 +21,24 @@ const serializeDoubleLinkedList = <T>(
 
   while (current) {
     const serializedNode: IDllSerializedNode<T> = {
+      key: current.key,
       value: current.value,
       prev: null,
       next: null,
     };
 
     if (current.prev) {
-      serializedNode.prev = current.prev.value;
+      serializedNode.prev = {
+        key: current.prev.key,
+        value: current.prev.value,
+      };
     }
 
     if (current.next) {
-      serializedNode.next = current.next.value;
+      serializedNode.next = {
+        key: current.next.key,
+        value: current.next.value,
+      };
     }
 
     serializedList.push(serializedNode);
@@ -42,17 +49,24 @@ const serializeDoubleLinkedList = <T>(
 
   while (currentPrev) {
     const serializedNode: IDllSerializedNode<T> = {
+      key: currentPrev.key,
       value: currentPrev.value,
       prev: null,
       next: null,
     };
 
     if (currentPrev.prev) {
-      serializedNode.prev = currentPrev.prev.value;
+      serializedNode.prev = {
+        key: currentPrev.prev.key,
+        value: currentPrev.prev.value,
+      };
     }
 
     if (currentPrev.next) {
-      serializedNode.next = currentPrev.next.value;
+      serializedNode.next = {
+        key: currentPrev.next.key,
+        value: currentPrev.next.value,
+      };
     }
 
     serializedList.push(serializedNode);
@@ -76,21 +90,21 @@ const deserializeDoubleLinkedList = <T>(
     return null;
   }
 
-  const nodeMap: Map<T, DoubleLinkedListNode<T>> = new Map();
+  const nodeMap: Map<string, DoubleLinkedListNode<T>> = new Map();
   let currentNode: DoubleLinkedListNode<T> | null = null;
 
   for (const item of data) {
-    const newNode = new DoubleLinkedListNode(item.value);
-    nodeMap.set(item.value, newNode);
+    const newNode = new DoubleLinkedListNode(item.key, item.value);
+    nodeMap.set(item.key, newNode);
 
-    if ((item.prev || item.prev === 0) && nodeMap.has(item.prev)) {
-      const prevNode = nodeMap.get(item.prev);
+    if (item.prev && nodeMap.has(item.prev.key)) {
+      const prevNode = nodeMap.get(item.prev.key);
       newNode.prev = prevNode;
       prevNode.next = newNode;
     }
 
-    if ((item.next || item.next === 0) && nodeMap.has(item.next)) {
-      const nextNode = nodeMap.get(item.next);
+    if (item.next && nodeMap.has(item.next.key)) {
+      const nextNode = nodeMap.get(item.next.key);
       newNode.next = nextNode;
       nextNode.prev = newNode;
     }

--- a/src/types/browserHistory.ts
+++ b/src/types/browserHistory.ts
@@ -1,11 +1,11 @@
 import { IDllSerializedList } from './dllSerialization';
 
-export interface ILocationState<T> {
-  pathname: string;
-  state: T;
+export interface ISerializedHistory<T> {
+  homePage: IDllSerializedList<T>;
+  currentPage: IDllSerializedList<T>;
 }
 
-export interface ISerializedHistory<T> {
-  homePage: IDllSerializedList<ILocationState<T>>;
-  currentPage: IDllSerializedList<ILocationState<T>>;
+export interface ILocationState<T> {
+  pathname: string;
+  state: T | undefined;
 }

--- a/src/types/dllSerialization.ts
+++ b/src/types/dllSerialization.ts
@@ -1,7 +1,8 @@
 interface IDllSerializedNode<T> {
+  key: string;
   value: T;
-  prev: T | null;
-  next: T | null;
+  prev: { key: string; value: T } | null;
+  next: { key: string; value: T } | null;
 }
 
 type IDllSerializedList<T> = IDllSerializedNode<T>[];


### PR DESCRIPTION
the browser history api was exposing a 'node' as opposed to url and associated state

BREAKING CHANGE: back and forward returns the pathname and state rather than a 'node'

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
